### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
the node_modules directory will cause problem when you do "git clone". Cause the file name is too long to handle for git.